### PR TITLE
Fixes for macOS 13

### DIFF
--- a/icons.go
+++ b/icons.go
@@ -22,7 +22,7 @@ const (
 
 // Ready-to-use icons based on macOS system icons. These icons are all found in
 //
-//     /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources
+//	/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources
 //
 // The icons are the same as found in the Alfred-Workflow library
 // for Python. Preview them here:
@@ -54,7 +54,7 @@ var (
 	IconSync      = &Icon{Value: sysIcons + "Sync.icns"}
 	IconTrash     = &Icon{Value: sysIcons + "TrashIcon.icns"}
 	IconUser      = &Icon{Value: sysIcons + "UserIcon.icns"}
-	IconWarning   = &Icon{Value: sysIcons + "AlertCautionIcon.icns"}
+	IconWarning   = &Icon{Value: sysIcons + "AlertCautionBadgeIcon.icns"}
 	IconWeb       = &Icon{Value: sysIcons + "BookmarkIcon.icns"}
 )
 
@@ -70,7 +70,7 @@ var (
 // Type = IconTypeFileIcon will treat Value as the path to a file or
 // directory and use that file's icon, e.g:
 //
-//    icon := &aw.Icon{"/Applications/Mail.app", aw.IconTypeFileIcon}
+//	icon := &aw.Icon{"/Applications/Mail.app", aw.IconTypeFileIcon}
 //
 // will display Mail.app's icon.
 //
@@ -81,7 +81,7 @@ var (
 // You can find out the UTI of a filetype by dragging one of the files
 // to a File Filter's File Types list in Alfred, or in a shell with:
 //
-//    mdls -name kMDItemContentType -raw /path/to/the/file
+//	mdls -name kMDItemContentType -raw /path/to/the/file
 //
 // This will only work on Spotlight-indexed files.
 type Icon struct {

--- a/util/scripts.go
+++ b/util/scripts.go
@@ -26,7 +26,7 @@ var (
 	// Used by the Script Runner (and by extension Run()) to determine
 	// how to run files that aren't executable.
 	DefaultInterpreters = map[string][]string{
-		".py":          {"/usr/bin/python"},
+		".py":          {"/usr/bin/python3"},
 		".rb":          {"/usr/bin/ruby"},
 		".sh":          {"/bin/bash"},
 		".zsh":         {"/bin/zsh"},

--- a/util/scripts_test.go
+++ b/util/scripts_test.go
@@ -26,7 +26,8 @@ func TestExecutableRunner(t *testing.T) {
 		{"/", false},
 		{"/bin", false},
 		// Existing paths
-		{"/usr/bin/python2.7", true}, // symlink on El Cap
+		{"/usr/bin/python2.7", false}, // Missing since macOS 12.3
+		{"/usr/bin/python3", true},    // Only included python since macOS 12.3
 		{"/bin/cp", true},
 		{"/bin/ls", true},
 		{"/bin/mv", true},

--- a/util/testdata/pythonx
+++ b/util/testdata/pythonx
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 

--- a/workflow_feedback_test.go
+++ b/workflow_feedback_test.go
@@ -23,7 +23,7 @@ func TestItemHelpers(t *testing.T) {
 	)
 
 	it := wf.NewWarningItem("Warn Title", "Warn subtitle")
-	x := `{"title":"Warn Title","subtitle":"Warn subtitle","valid":false,"icon":{"path":"/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertCautionIcon.icns"}}`
+	x := `{"title":"Warn Title","subtitle":"Warn subtitle","valid":false,"icon":{"path":"/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertCautionBadgeIcon.icns"}}`
 	data, err = json.Marshal(it)
 	assert.Nil(t, err, "marshal Item failed")
 	js := string(data)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -337,7 +337,7 @@ func ExampleWorkflow_Warn() {
 	//       "subtitle": "Those items are boring",
 	//       "valid": false,
 	//       "icon": {
-	//         "path": "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertCautionIcon.icns"
+	//         "path": "/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertCautionBadgeIcon.icns"
 	//       }
 	//     }
 	//   ]


### PR DESCRIPTION
* Removes python2 and points to python3
* Replaces AlertCautionIcon with AlertCautionBadgeIcon

The icon isn't a great replacement, but it's the best of the bad options for now